### PR TITLE
Hide/show the panel explicitly after/before the animation

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -14,6 +14,7 @@ const PANEL_ANIMATION_DURATION = 150;
 
 export default class PanelFreeExtension {
     _showPanel() {
+        Main.panel.show();
         Main.panel.ease({
             duration: PANEL_ANIMATION_DURATION,
             height: this._originalPanelHeight,
@@ -25,7 +26,8 @@ export default class PanelFreeExtension {
         Main.panel.ease({
             duration: PANEL_ANIMATION_DURATION,
             height: 0,
-            mode: Clutter.AnimationMode.EASE_OUT_QUAD
+            mode: Clutter.AnimationMode.EASE_OUT_QUAD,
+            onComplete: () => Main.panel.hide()
         });
     }
 


### PR DESCRIPTION
When the hide animation is done the panel is still visible as a 1-pixel line, as shown in the following screenshot (top-left portion):

![1_pixel_panel](https://github.com/fthx/panel-free/assets/1242232/342687f2-479c-4878-b0d4-529b07f99ad7)

Hiding it explicitly after the animation fixes the problem.