### PR TITLE
Hide/show first_child for all items on panel

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -11,13 +11,17 @@ import * as Main from 'resource:///org/gnome/shell/ui/main.js';
 
 export default class PanelFreeExtension {
     _showPanel() {
-        Main.panel.statusArea['activities'].first_child.show();
+        for (const item in Main.panel.statusArea) {
+            Main.panel.statusArea[item].first_child.show();
+        }
         Main.panel.set_height(this._originalPanelHeight);
     }
 
     _hidePanel() {
         Main.panel.set_height(0);
-        Main.panel.statusArea['activities'].first_child.hide();
+        for (const item in Main.panel.statusArea) {
+            Main.panel.statusArea[item].first_child.hide();
+        }
     }
 
     enable() {


### PR DESCRIPTION
In reference to https://github.com/fthx/panel-free/pull/3#issuecomment-1824099470, the nice solution for the `activities` item should be applied to all items on the panel.