### PR TITLE
feat: Keep panel visible on desktop

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -7,27 +7,52 @@
 
 
 import * as Main from 'resource:///org/gnome/shell/ui/main.js';
+import { global } from 'resource:///org/gnome/shell/ui/environment.js';
 
 
 export default class PanelFreeExtension {
-    _showPanel() {
-        Main.panel.visible = true;
-    }
+    /**
+     * This function checks the current state (in overview or number of windows)
+     * and sets the panel's visibility accordingly.
+     */
+    _updatePanelVisibility() {
+        // global.get_window_actors() gets a list of all open windows.
+        // If the length is 0, it means no windows are open, so we are on the desktop.
+        const onDesktop = global.get_window_actors().length === 0;
 
-    _hidePanel() {
-        Main.panel.visible = false;
+        if (Main.overview.visible || onDesktop) {
+            Main.panel.visible = true;
+        } else {
+            Main.panel.visible = false;
+        }
     }
 
     enable() {
-        this._hidePanel();
+        // We use connectObject to easily manage and disconnect signals related to the overview.
+        Main.overview.connectObject(
+            'showing', this._updatePanelVisibility.bind(this),
+            'hiding', this._updatePanelVisibility.bind(this),
+            this
+        );
 
-        Main.overview.connectObject('showing', this._showPanel.bind(this), this);
-        Main.overview.connectObject('hiding', this._hidePanel.bind(this), this);
+        // We also need to react to windows being opened or closed.
+        // The 'notify::n-windows' signal on global.window_manager is emitted whenever
+        // the number of open windows changes.
+        this._windowSignalId = global.window_manager.connect('notify::n-windows', this._updatePanelVisibility.bind(this));
+
+        // Set the initial state of the panel when the extension is enabled.
+        this._updatePanelVisibility();
     }
 
     disable() {
+        // Disconnect the signal handlers to clean up.
         Main.overview.disconnectObject(this);
+        if (this._windowSignalId) {
+            global.window_manager.disconnect(this._windowSignalId);
+            this._windowSignalId = null;
+        }
 
-        this._showPanel();
+        // Ensure the panel is visible when the extension is disabled.
+        Main.panel.visible = true;
     }
 }


### PR DESCRIPTION
This pull request modifies the extension's behavior to keep the top panel visible not only in the Activities Overview but also on the desktop when no application windows are open. The panel will remain hidden when an application window is active, preserving a distraction-free environment.

## Changes
- Centralized Visibility Logic: Introduced a new _updatePanelVisibility() method to handle the logic for showing or hiding the panel based on the current context.
- Desktop Detection: The extension now checks the number of open window actors using global.get_window_actors().length. If there are no windows open, the panel is made visible.
- Dynamic Updates: Added a signal listener for notify::n-windows on global.window_manager. This allows the panel's visibility to be updated dynamically whenever a window is opened or closed, ensuring the panel correctly appears on the desktop and hides for applications.
- Cleanup: Ensured all new signal connections are properly disconnected in the disable() method to prevent memory leaks.